### PR TITLE
Fix oneOf to require at least one check

### DIFF
--- a/lib/OpenAPI/Schema/Validate.pm6
+++ b/lib/OpenAPI/Schema/Validate.pm6
@@ -110,6 +110,10 @@ class OpenAPI::Schema::Validate {
                     when X::OpenAPI::Schema::Validate::Failed {}
                 }
             }
+            unless $check {
+                die X::OpenAPI::Schema::Validate::Failed.new:
+                    :$!path, :reason('Does not satisfy exactly one check');
+            }
         }
     }
 

--- a/t/modifiers.t
+++ b/t/modifiers.t
@@ -36,6 +36,7 @@ use Test;
     });
     ok $schema.validate(1), 'oneOf accepted single-matched integer';
     nok $schema.validate('string'), 'oneOf rejected string matched twice';
+    nok $schema.validate({}), 'oneOf rejected object';
 }
 
 {


### PR DESCRIPTION
OneCheck prevents multiple checks from succeeding, but doesn't require at least one to succeed.
