### PR TITLE
`required` should allow undefined values

### DIFF
--- a/lib/OpenAPI/Schema/Validate.pm6
+++ b/lib/OpenAPI/Schema/Validate.pm6
@@ -322,9 +322,14 @@ class OpenAPI::Schema::Validate {
     my class RequiredCheck does Check {
         has Str @.prop;
         method check($value --> Nil) {
-            if $value ~~ Associative && not [&&] $value{@!prop}.map(*.defined) {
-                die X::OpenAPI::Schema::Validate::Failed.new:
-                    :$!path, :reason("Object does not have required property");
+            if $value ~~ Associative {
+                for @!prop -> $needle {
+                    if !$value{$needle}.defined {
+                        die X::OpenAPI::Schema::Validate::Failed.new:
+                            :$!path,
+                            :reason("Object does not have required property: \"$needle\"");
+                    }
+                }
             }
         }
     }

--- a/lib/OpenAPI/Schema/Validate.pm6
+++ b/lib/OpenAPI/Schema/Validate.pm6
@@ -324,7 +324,7 @@ class OpenAPI::Schema::Validate {
         method check($value --> Nil) {
             if $value ~~ Associative {
                 for @!prop -> $needle {
-                    if !$value{$needle}.defined {
+                    if $value{$needle}:!exists {
                         die X::OpenAPI::Schema::Validate::Failed.new:
                             :$!path,
                             :reason("Object does not have required property: \"$needle\"");

--- a/t/modifiers.t
+++ b/t/modifiers.t
@@ -74,6 +74,22 @@ use Test;
         type => 'object',
         required => ['username'],
         properties => {
+            username => {
+                type => 'string',
+                nullable => True
+            }
+        }
+    });
+    ok $schema.validate({username => 'Zero'}), 'String accepted when nullable is True and property is required';
+    ok $schema.validate({username => Str}), 'Type object accepted when nullable is True and property is required';
+    nok $schema.validate({}), 'Missing property rejected when nullable is True and property is required';
+}
+
+{
+    my $schema = OpenAPI::Schema::Validate.new(schema => {
+        type => 'object',
+        required => ['username'],
+        properties => {
             username => { type => 'string' },
             lastTimeOnline => { readOnly => True, type => 'string' }
         }


### PR DESCRIPTION
Required means the property exists, not necessarily that it has a defined value.
Not the best reference, but still: [Stackoverflow answer](https://stackoverflow.com/a/45577763).