### PR TITLE
Better errors

### DIFF
--- a/lib/OpenAPI/Schema/Validate.pm6
+++ b/lib/OpenAPI/Schema/Validate.pm6
@@ -102,17 +102,17 @@ class OpenAPI::Schema::Validate {
         method check($value --> Nil) {
             my $succeed-num = 0;
             my @reasons;
-            for @!checks.kv -> $i, $c {
+            CHECK_LOOP: for @!checks.kv -> $i, $c {
                 {
                     $c.check($value);
                     CATCH {
                         when X::OpenAPI::Schema::Validate::Failed {
                             @reasons.push: "{.path}/{$i + 1}: {.reason}";
-                            next;
+                            next CHECK_LOOP; # For some reason a plain `next` here acts like `.resume`
                         }
                         default {
                             @reasons.push: "Other exception found: {$_.WHAT.^name}";
-                            next;
+                            next CHECK_LOOP;
                         }
                     }
                 }

--- a/lib/OpenAPI/Schema/Validate.pm6
+++ b/lib/OpenAPI/Schema/Validate.pm6
@@ -133,14 +133,16 @@ class OpenAPI::Schema::Validate {
     my class NotCheck does Check {
         has Check $.check;
         method check($value --> Nil) {
-            $!check.check($value);
-            CATCH {
-                when X::OpenAPI::Schema::Validate::Failed {
-                    return;
+            {
+                $!check.check($value);
+                CATCH {
+                    when X::OpenAPI::Schema::Validate::Failed {
+                        return;
+                    }
                 }
             }
-            fail X::OpenAPI::Schema::Validate::Failed.new:
-                :$!path, :reason('Value passed check check');
+            die X::OpenAPI::Schema::Validate::Failed.new:
+                :$!path, :reason('Value passed not check');
         }
     }
 


### PR DESCRIPTION
This is an assortment of improved error messages that now print in more detail how validations failed.
I might have also fixed a bug in `oneOf`, though I'm not entirely sure it was actually broken before I started work on this.